### PR TITLE
Fixed CMake configs

### DIFF
--- a/PROJECTINFO.cmake
+++ b/PROJECTINFO.cmake
@@ -4,7 +4,8 @@ SET( BASELIB		"yui" )		# don't change this
 
 ##### MAKE ALL NEEDED CHANGES HERE #####
 
-SET( SUBDIRS		src examples tests )
+SET( PLUGINNAME         testing-framework )
+SET( SUBDIRS		src )
 SET( LIB_DEPS		Boost )
 SET( LIB_LINKER		dl pthread microhttpd jsoncpp )
 SET( EXTRA_INCLUDES     )         # set include-dir which are not picked by CMake automagically here.

--- a/SOURCECONF.cmake
+++ b/SOURCECONF.cmake
@@ -25,13 +25,3 @@ SET( ${TARGETLIB}_HEADERS
  YJsonSerializer.h
 )
 
-SET( EXAMPLES_LIST
-  ComboBox1.cc
-  ComboBox1-editable.cc
-  HelloWorld.cc
-  SelectionBox1.cc
-  SelectionBox2.cc
-  SelectionBox3-many-items.cc
-  Table-many-items.cc
-  ManyWidgets.cc
-)


### PR DESCRIPTION
- This fixes the `could not find LibyuiCommon` error
- The fix is to set the `PLUGINNAME`, otherwise the CMake config you are in the `libyui` base package and wants to load the file from the local path, not from `/usr/...`
- Fixed also the directory list
- TODO: add the new files, CMake complains it cannot find the defined sources

## Build Hints

You can build the package locally quite easily with this trick:

```shell
cd package
# initializes the osc environment, creates a new local package built against YaST:Head
# it is NOT created on the server so you can safely play with that
osc init YaST:Head libyui-testframework

# now repeat these steps to build the package locally:
rake tarball
osc build --local-package
```

But the osc build takes quite some time, it's better to start building/compiling locally and then play with the RPM packaging, from the sources root do:

```shell
# initialize CMake etc..
make -f Makefile.cvs

# then just call
make -C build
```

